### PR TITLE
add taxonomy to biom

### DIFF
--- a/qp_woltka/tests/test_woltka.py
+++ b/qp_woltka/tests/test_woltka.py
@@ -12,9 +12,11 @@ from qiita_client import ArtifactInfo
 from os import remove, environ
 from os.path import exists, isdir, join, dirname
 from shutil import rmtree, copyfile
-from qp_woltka import plugin
 from tempfile import mkdtemp
 from json import dumps
+from biom import load_table
+
+from qp_woltka import plugin
 from qp_woltka.util import get_dbs, generate_woltka_dflt_params
 from qp_woltka.woltka import woltka_to_array, woltka
 
@@ -384,6 +386,12 @@ class WoltkaTests(PluginTestCase):
                          [(f'{out_dir}/per-gene.biom', 'biom')])]
 
         self.assertCountEqual(ainfo, exp)
+
+        # check that the produced table have feature taxonomy
+        bt = load_table(f'{out_dir}/phylum.biom')
+        self.assertCountEqual(
+            bt.metadata_to_dataframe('observation').columns,
+            ['taxonomy_0', 'taxonomy_1'])
 
     def test_woltka_to_array_error(self):
         # inserting new prep template

--- a/qp_woltka/woltka.py
+++ b/qp_woltka/woltka.py
@@ -9,6 +9,8 @@ from math import ceil
 from os import environ
 from os.path import join, basename, exists
 from glob import glob
+from biom.util import biom_open
+from biom import load_table
 import re
 
 from qiita_client import ArtifactInfo
@@ -293,7 +295,16 @@ def woltka(qclient, job_id, parameters, out_dir):
 
     for rank in ['phylum', 'genus', 'species']:
         fp = f'{out_dir}/{rank}.biom'
+
         if exists(fp):
+            # making sure that the tables have taxonomy
+            bt = load_table(fp)
+            metadata = {x: {'taxonomy': x.split(';')}
+                        for x in bt.ids(axis='observation')}
+            bt.add_metadata(metadata, axis='observation')
+            with biom_open(fp, 'w') as f:
+                bt.to_hdf5(f, "shogun")
+
             ainfo.append(ArtifactInfo(f'Taxonomic Predictions - {rank}',
                                       'BIOM', [(fp, 'biom')]))
         else:

--- a/qp_woltka/woltka.py
+++ b/qp_woltka/woltka.py
@@ -303,7 +303,7 @@ def woltka(qclient, job_id, parameters, out_dir):
                         for x in bt.ids(axis='observation')}
             bt.add_metadata(metadata, axis='observation')
             with biom_open(fp, 'w') as f:
-                bt.to_hdf5(f, "shogun")
+                bt.to_hdf5(f, "woltka")
 
             ainfo.append(ArtifactInfo(f'Taxonomic Predictions - {rank}',
                                       'BIOM', [(fp, 'biom')]))


### PR DESCRIPTION
If we want the analysis plugin to be able to generate Taxonomy plots, we need to add the taxonomy to the files. This step was left out this plugin by mistake.